### PR TITLE
platform for device token

### DIFF
--- a/App/Containers/Login.js
+++ b/App/Containers/Login.js
@@ -129,7 +129,7 @@ class Login extends React.Component {
   }
 
   async successLogin (data) {
-    let platform = Platform.OS === 'ios' ? 'ios' : 'android'
+    let platform = Platform.OS === 'ios' ? 'ios_fcm' : 'android'
     let tokenType = null
     FCM.requestPermissions({badge: false, sound: true, alert: true})
 


### PR DESCRIPTION
new platform. basicly when platform ios always use apns/pushkit and android use fcm. but especialy for RN we're using ios_fcm